### PR TITLE
Update vue.md

### DIFF
--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -2,26 +2,22 @@
 
 Vue follows a similar pattern to [React](./react.md):
 
-- The machine can be defined externally
-- The service is placed on the `data` object
-- State changes are observed via `service.onTransition(state => ...)`, where you set some data property to the next `state`
-- The service is started (`service.start()`) when the component is `created()`
+- The machine can be defined externally;
+- The service is placed on the `data` object;
+- State changes are observed via `service.onTransition(state => ...)`, where you set some data property to the next `state`;
+- The machine's context can be referenced as an external data store by the app. Context changes are also observed via `service.onTransition(state => ...)`, where you set another data property to the updated context;
+- The service is started (`service.start()`) when the component is `created()`;
 - Events are sent to the service via `service.send(event)`.
 
-```html
-<!-- Toggle.vue -->
-<template>
-  <button v-on:click="send('TOGGLE');">
-    {{ current.matches("inactive") ? "Off" : "On" }}
-  </button>
-</template>
+```js
+import { Machine } from 'xstate';
 
-<script>
-  import { Machine, interpret } from 'xstate';
-
-  // Define machine externally
+// This machine is completely decoupled from Vue
   const toggleMachine = Machine({
     id: 'toggle',
+    context: {
+      /* some data */
+    },
     initial: 'inactive',
     states: {
       inactive: {
@@ -32,6 +28,19 @@ Vue follows a similar pattern to [React](./react.md):
       }
     }
   });
+```
+
+```html
+<!-- Toggle.vue -->
+<template>
+  <button v-on:click="send('TOGGLE');">
+    {{ current.matches("inactive") ? "Off" : "On" }}
+  </button>
+</template>
+
+<script>
+  import { interpret } from 'xstate';
+  import { toggleMachine } from '../path/to/toggleMachine';
 
   export default {
     name: 'Toggle',
@@ -39,7 +48,10 @@ Vue follows a similar pattern to [React](./react.md):
       // Start service on component creation
       this.toggleService
         .onTransition(state => {
+          // Update the current state component data property with the next state
           this.current = state;
+          // Update the context componenet data property with the updated context
+          this.context = state.context;
         })
         .start();
     },
@@ -48,8 +60,11 @@ Vue follows a similar pattern to [React](./react.md):
         // Interpret machine and store it in data
         toggleService: interpret(toggleMachine),
 
-        // Start with machine's initial state
-        current: toggleMachine.initialState
+        // Start with the machine's initial state
+        current: toggleMachine.initialState,
+  
+        // Start with the machine's initial context
+        context: toggleMachine.context
       };
     },
     methods: {


### PR DESCRIPTION
Add a context property to the machine's definition
Explain that the context can act as a data store and how it can be updated and referenced on the component instance
Move the machine definition to another file to better represent the decoupling between the machine and Vue (like in the react example)